### PR TITLE
Add SQL file for uninstalling this extension

### DIFF
--- a/sql/pcpteams-uninstall.sql
+++ b/sql/pcpteams-uninstall.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS `civicrm_pcp_team`;
+DROP TABLE IF EXISTS `civicrm_pcp_block_team`;
+
+DELETE FROM `civicrm_msg_template`
+WHERE `msg_title` = 'Contributions - PCP contribution notification';
+
+SELECT @option_group_id_contribution := max(id)
+FROM `civicrm_option_group`
+WHERE `name` = 'msg_tpl_workflow_contribution';
+
+DELETE FROM `civicrm_option_value`
+WHERE
+  `option_group_id` = @option_group_id_contribution AND
+  `name` = 'pcpteams_notification_contribution';


### PR DESCRIPTION
This PR makes it possible to uninstall this extension.

### Before

* Attempting to uninstall this extension gives an error that the SQL file is not found. 
* There appears to be no way successfully uninstall it

Caveat: I'm only testing with 4.7. Perhaps somehow this extension does uninstall itself on 4.6 (though I'd be very surprised if that were the case!)

### After 

* Uninstalling the extension succeeds. 
* Tables, option values, and message templates are removed 